### PR TITLE
Limit request body size to 64KB

### DIFF
--- a/server.go
+++ b/server.go
@@ -43,10 +43,15 @@ func (srv *Server) recoverKey(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	in, err := io.ReadAll(req.Body)
+	const maxBodySize = 64*1024 // 64KB
+
+	in, err := io.ReadAll(io.LimitReader(req.Body, maxBodySize+1))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+	if len(in) > maxBodySize {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
 	}
 
 	thp := req.RequestURI[5:]

--- a/server.go
+++ b/server.go
@@ -52,6 +52,7 @@ func (srv *Server) recoverKey(w http.ResponseWriter, req *http.Request) {
 	}
 	if len(in) > maxBodySize {
 		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
 	}
 
 	thp := req.RequestURI[5:]

--- a/server_test.go
+++ b/server_test.go
@@ -210,6 +210,21 @@ func encryptWithTang(t *testing.T, nativeTang bool, thp string, errorMessage str
 	require.Contains(t, string(cmdErr.Bytes()), errorMessage)
 }
 
+func TestRecoverKeyBodyTooLarge(t *testing.T) {
+	t.Parallel()
+
+	port, stopTang := startTangd(t, 0)
+	defer stopTang()
+
+	// Create a body larger than 64KB
+	body := bytes.Repeat([]byte("x"), 64*1024+1)
+
+	url := fmt.Sprintf("http://localhost:%d/rec/somethumbprint", port)
+	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
 func TestEncryptWithInvalidThp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Without a size limit, an attacker could exhaust server memory by sending unbounded request bodies. Cap at 64KB for parity with the C implementation.

64KB limit defined: https://github.com/latchset/tang/blob/97cffa4e2b7e60c7f363571a2acdf596effac575/src/http.h#L62

HTTP_STATUS_PAYLOAD_TOO_LARGE when request is too large: https://github.com/latchset/tang/blob/97cffa4e2b7e60c7f363571a2acdf596effac575/src/http.c#L60

`go test ./...` passes on my Debian 13 server.
